### PR TITLE
fix: add spellcheck and spellcheck-sort to 'make help'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,11 +3,11 @@ help:
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n"} /^[a-zA-Z_0-9-]+:.*?##/ { printf "  \033[36m%-18s\033[0m %s\n", $$1, $$2 } /^##@/ { printf "\n\033[1m%s\033[0m\n", substr($$0, 5) } ' $(MAKEFILE_LIST)
 
 .PHONY: spellcheck
-spellcheck: .spellcheck.yml
+spellcheck: .spellcheck.yml ## Spellcheck markdown files
 	pyspelling --config $<
 
 .PHONY: spellcheck-sort
-spellcheck-sort: .spellcheck-en-custom.txt
+spellcheck-sort: .spellcheck-en-custom.txt ## Sort spellcheck directory
 	sort -d -f -o $< $<
 
 #


### PR DESCRIPTION
Example of before/after below
```bash
[nathan@nathan-redhat .github (make-help)]$ make help

Usage:
  make <target>
  md-lint             Lint markdown files
[nathan@nathan-redhat .github (make-help)]$ make help

Usage:
  make <target>
  spellcheck          Spellcheck markdown files
  spellcheck-sort     Sort spellcheck directory
  md-lint             Lint markdown files
```