### PR TITLE
docs: Updating contribution links under get started

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -25,7 +25,8 @@ Check out [InstructLab on Hugging Face](https://huggingface.co/instructlab).
 ## Get started
 
 * [Install InstructLab locally](https://docs.instructlab.ai/getting-started/mac_metal/)
-* [Contribute to the project](https://github.com/instructlab/instructlab/blob/main/CONTRIBUTING/CONTRIBUTING.md)
+* [Contribute to the InstructLab community model](https://docs.instructlab.ai/taxonomy/)
+* [Contribute to the CLI project code](https://github.com/instructlab/instructlab/blob/main/CONTRIBUTING/CONTRIBUTING.md)
 * [Connect with the community](https://github.com/instructlab/community/blob/main/Collaboration.md) to share feedback and ideas, ask questions, and troubleshoot issues.
 
 ## Additional information


### PR DESCRIPTION
Updating the contribution links in the front page README to disambiguate between codebase contributions and taxonomy contributions.