### PR TITLE
add references to discord

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,7 +4,7 @@ The InstructLab team and community take security bugs seriously. We appreciate y
 
 ## Reporting a Vulnerability
 
-If you think you've identified a security issue in an InstructLab project repository, please DO NOT report the issue publicly via the GitHub issue tracker, Slack Workspace, etc.
+If you think you've identified a security issue in an InstructLab project repository, please DO NOT report the issue publicly via the GitHub issue tracker, Slack Workspace, Discord server, etc.
 
 Instead, send an email with as many details as possible to [security-reporting@instructlab.ai](mailto:security-reporting@instructlab.ai). This is a private mailing list for the security team.
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 # Welcome to the 🐶 InstructLab Project
 
-Quick Links: [Documentation](https://docs.instructlab.ai/) | [FAQ](https://docs.instructlab.ai/community/FAQ/) | [Hugging Face](https://huggingface.co/instructlab) | [Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f@group.calendar.google.com) | [Slack](https://join.slack.com/t/instruct-lab/shared_invite/zt-2kieyqiz9-zhXSxGnXk6uL_f3hVbD53g) | [YouTube](https://www.youtube.com/@InstructLab) | [X](https://x.com/InstructLab) | [Reddit](https://www.reddit.com/r/instructlab/)
+Quick Links: [Documentation](https://docs.instructlab.ai/) | [FAQ](https://docs.instructlab.ai/community/FAQ/) | [Hugging Face](https://huggingface.co/instructlab) | [Calendar](https://calendar.google.com/calendar/u/0/embed?src=c_23c2f092cd6d147c45a9d2b79f815232d6c3e550b56c3b49da24c4b5d2090e8f@group.calendar.google.com) | [Discord](https://instructlab.ai/discord) | [Slack](https://join.slack.com/t/instruct-lab/shared_invite/zt-2kieyqiz9-zhXSxGnXk6uL_f3hVbD53g) | [YouTube](https://www.youtube.com/@InstructLab) | [X](https://x.com/InstructLab) | [Reddit](https://www.reddit.com/r/instructlab/)
 
 ![Banner](https://github.com/instructlab/.github/blob/main/assets/instructlab-banner.png)
 


### PR DESCRIPTION
Due to the introduction of the InstructLab Discord server, this PR updates the `.github` repo to include links to the Discord server and references it in the security policy. 

Signed-off-by: Oleg S <97077423+RobotSail@users.noreply.github.com>
